### PR TITLE
Java 23 Support

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--enable-preview

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FDA Shield - Client
 
 Follow the instructions below to set up the local environment for `ikm-framework`:
 
-1. Download and install Open JDK Java 19
+1. Download and install Open JDK Java 23
 
 2. Download and install Apache Maven 3.9 or greater
 

--- a/komet-orchestrator/pom.xml
+++ b/komet-orchestrator/pom.xml
@@ -15,9 +15,9 @@
     <name>Komet µsOrchestrator</name>
 
     <properties>
-        <junit.version>5.10.0</junit.version>
+        <junit.version>5.12.0</junit.version>
         <javafx.version>21.0.1</javafx.version>
-        <lucene-core.version>10.1.0</lucene-core.version>
+        <lucene-core.version>9.12.1</lucene-core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
     </properties>

--- a/komet-orchestrator/pom.xml
+++ b/komet-orchestrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <artifactId>komet-orchestrationService</artifactId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>dev.ikm</groupId>
             <artifactId>orchestration-interfaces</artifactId>
-            <version>3.0.1-SNAPSHOT</version>
+            <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/komet-orchestrator/pom.xml
+++ b/komet-orchestrator/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <junit.version>5.10.0</junit.version>
         <javafx.version>21.0.1</javafx.version>
-        <lucene-core.version>9.7.0</lucene-core.version>
+        <lucene-core.version>10.1.0</lucene-core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
     </properties>
@@ -110,8 +110,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>21</release>
+                    <release>23</release>
                     <compilerArgs>
+                        <arg>${java.compilerArgs}</arg>
                         <arg>--add-exports</arg>
                         <arg>javafx.controls/com.sun.javafx.scene.control.behavior=dev.ikm.komet.navigator</arg>
                     </compilerArgs>

--- a/komet-orchestrator/pom.xml
+++ b/komet-orchestrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>komet-orchestrationService</artifactId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>dev.ikm</groupId>
             <artifactId>orchestration-interfaces</artifactId>
-            <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+            <version>3.0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/orchestration-interfaces/pom.xml
+++ b/orchestration-interfaces/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>orchestration-interfaces</artifactId>

--- a/orchestration-interfaces/pom.xml
+++ b/orchestration-interfaces/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <artifactId>orchestration-interfaces</artifactId>

--- a/orchestration-interfaces/pom.xml
+++ b/orchestration-interfaces/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>orchestration-interfaces</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/orchestration-provider/changeset-writer/pom.xml
+++ b/orchestration-provider/changeset-writer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/changeset-writer/pom.xml
+++ b/orchestration-provider/changeset-writer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/changeset-writer/pom.xml
+++ b/orchestration-provider/changeset-writer/pom.xml
@@ -13,8 +13,8 @@
     <artifactId>changeset-writer</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/orchestration-provider/data-services/pom.xml
+++ b/orchestration-provider/data-services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/data-services/pom.xml
+++ b/orchestration-provider/data-services/pom.xml
@@ -13,8 +13,8 @@
     <artifactId>data-services</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/orchestration-provider/data-services/pom.xml
+++ b/orchestration-provider/data-services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/general-menu-provider/pom.xml
+++ b/orchestration-provider/general-menu-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/general-menu-provider/pom.xml
+++ b/orchestration-provider/general-menu-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/general-menu-provider/pom.xml
+++ b/orchestration-provider/general-menu-provider/pom.xml
@@ -13,8 +13,8 @@
     <artifactId>general-menu-provider</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/orchestration-provider/pom.xml
+++ b/orchestration-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/orchestration-provider/pom.xml
+++ b/orchestration-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/orchestration-provider/pom.xml
+++ b/orchestration-provider/pom.xml
@@ -14,8 +14,8 @@
     <artifactId>orchestration-provider</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/orchestration-provider/stats-menu-provider/pom.xml
+++ b/orchestration-provider/stats-menu-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/stats-menu-provider/pom.xml
+++ b/orchestration-provider/stats-menu-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/stats-menu-provider/pom.xml
+++ b/orchestration-provider/stats-menu-provider/pom.xml
@@ -13,8 +13,8 @@
     <artifactId>stats-menu-provider</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/orchestration-provider/sync-provider/pom.xml
+++ b/orchestration-provider/sync-provider/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>sync-provider</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 <dependencies>

--- a/orchestration-provider/sync-provider/pom.xml
+++ b/orchestration-provider/sync-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
     <groupId>dev.ikm.orchestration.provider</groupId>
     <artifactId>sync-provider</artifactId>

--- a/orchestration-provider/sync-provider/pom.xml
+++ b/orchestration-provider/sync-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
     <groupId>dev.ikm.orchestration.provider</groupId>
     <artifactId>sync-provider</artifactId>

--- a/orchestration-provider/window-menu-provider/pom.xml
+++ b/orchestration-provider/window-menu-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/orchestration-provider/window-menu-provider/pom.xml
+++ b/orchestration-provider/window-menu-provider/pom.xml
@@ -13,8 +13,8 @@
     <artifactId>window-menu-provider</artifactId>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/orchestration-provider/window-menu-provider/pom.xml
+++ b/orchestration-provider/window-menu-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.orchestration</groupId>
         <artifactId>orchestration-provider</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.ikm.orchestration.provider</groupId>

--- a/plugin-layer/pom.xml
+++ b/plugin-layer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>plugin-layer</artifactId>

--- a/plugin-layer/pom.xml
+++ b/plugin-layer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <artifactId>plugin-layer</artifactId>

--- a/plugin-layer/pom.xml
+++ b/plugin-layer/pom.xml
@@ -15,8 +15,8 @@
 
     <properties>
         <jna.version>5.14.0</jna.version>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/plugin-service-loader/pom.xml
+++ b/plugin-service-loader/pom.xml
@@ -14,8 +14,8 @@
     <name>IKM Plugin Service Loader</name>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/plugin-service-loader/pom.xml
+++ b/plugin-service-loader/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>plugin-service-loader</artifactId>

--- a/plugin-service-loader/pom.xml
+++ b/plugin-service-loader/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm</groupId>
         <artifactId>ikm-framework</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1-AR-299_Java23-SNAPSHOT</version>
     </parent>
 
     <artifactId>plugin-service-loader</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<junit.version>5.10.0</junit.version>
+		<junit.version>5.12.0</junit.version>
 		<log4j-slf4j2.version>3.0.0-beta2</log4j-slf4j2.version>
-		<maven.compiler.release>21</maven.compiler.release>
+		<maven.compiler.release>23</maven.compiler.release>
 		<slf4j.version>2.0.13</slf4j.version>
-		<komet.version>1.38.0-SNAPSHOT</komet.version>
-		<tinkar.version>1.77.0</tinkar.version>
+		<komet.version>1.48.0-SNAPSHOT</komet.version>
+		<tinkar.version>1.85.0</tinkar.version>
 		<jgit.version>6.10.0.202406032230-r-r5</jgit.version>
 		<maven.github-flow.version>1.21.1-r4</maven.github-flow.version>
 	</properties>
@@ -25,7 +25,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.14.0</version>
 			</plugin>
 			<plugin>
 				<groupId>dev.ikm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>dev.ikm</groupId>
 	<artifactId>ikm-framework</artifactId>
-	<version>3.0.1-AR-299_Java23-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<name>IKM Framework</name>
 	<packaging>pom</packaging>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 		<junit.version>5.12.0</junit.version>
 		<log4j-slf4j2.version>3.0.0-beta2</log4j-slf4j2.version>
 		<maven.compiler.release>23</maven.compiler.release>
+		<java.compilerArgs>--enable-preview</java.compilerArgs>
 		<slf4j.version>2.0.13</slf4j.version>
 		<komet.version>1.48.0-SNAPSHOT</komet.version>
 		<tinkar.version>1.85.0</tinkar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>dev.ikm</groupId>
 	<artifactId>ikm-framework</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>3.0.1-AR-299_Java23-SNAPSHOT</version>
 	<name>IKM Framework</name>
 	<packaging>pom</packaging>
 	<properties>


### PR DESCRIPTION
Changes needed for Java 23:

* Add jvm.config and enable-preview flag
* Update Maven (wrapper) to 3.9.9
* Update Maven dependencies
* Change source/target to Java 23

Not changed:

* There are no GitHub actions defined.
* Does not use the build parent
* Makes reference to snapshot dependency